### PR TITLE
Public URLs and build fix for Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "bgfx"]
 	path = bgfx
-	url = git@github.com:bkaradzic/bgfx.git
+	url = https://github.com/bkaradzic/bgfx.git
 [submodule "bx"]
 	path = bx
-	url = git@github.com:bkaradzic/bx.git
+	url = https://github.com/bkaradzic/bx.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ project( bgfx )
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 if( APPLE )
 	set( CMAKE_CXX_FLAGS "-ObjC++ --std=c++11" )
+elseif(UNIX)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 option( BGFX_BUILD_TOOLS    "Build bgfx tools."           ON  )
@@ -54,7 +57,7 @@ if( BGFX_INSTALL )
 
 	# install tools
 	if( BGFX_BUILD_TOOLS )
-		install( TARGETS shaderc DESTINATION bin )
+        install( TARGETS shaderc DESTINATION bin )
 		install( TARGETS geometryc DESTINATION bin )
 	endif()
 endif()

--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -14,10 +14,13 @@ include( cmake/3rdparty/fcpp.cmake )
 include( cmake/3rdparty/glsl-optimizer.cmake )
 include( cmake/3rdparty/glslang.cmake )
 
+find_package(Threads)
+
 add_executable( shaderc ${BGFX_DIR}/tools/shaderc/shaderc.cpp ${BGFX_DIR}/tools/shaderc/shaderc.h ${BGFX_DIR}/tools/shaderc/shaderc_glsl.cpp ${BGFX_DIR}/tools/shaderc/shaderc_hlsl.cpp ${BGFX_DIR}/tools/shaderc/shaderc_pssl.cpp ${BGFX_DIR}/tools/shaderc/shaderc_spirv.cpp )
 target_compile_definitions( shaderc PRIVATE "-D_CRT_SECURE_NO_WARNINGS" )
 set_target_properties( shaderc PROPERTIES FOLDER "bgfx/tools" )
 target_link_libraries( shaderc bx bgfx-vertexdecl bgfx-shader-spirv fcpp glsl-optimizer glslang )
+target_link_libraries( shaderc ${CMAKE_THREAD_LIBS_INIT})
 add_dependencies( tools shaderc )
 
 function( add_shader ARG_FILE )


### PR DESCRIPTION
Public URLs allows cloning without worrying about SSH keys.

Took a while, but finally figured out why the build was failing. Required C++11 flag and linking with `pthread` (funny enough, CMake's `add_compile_option` and `target_compile_option` doesn't seem to work with the option `-lpthread` or `-pthread`). Tested on Linux Mint with `gcc 5.4` and `clang 3.8`.