### PR TITLE
Added Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: required
+dist: precise
+language: cpp
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - g++-5
+            - cmake
+            - cmake-data
+      env: COMPILER=g++-5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+            - george-edison55-precise-backports 
+          packages:
+            - clang-3.8
+            - cmake
+            - cmake-data
+      env: COMPILER=clang++-3.8
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libglew-dev
+
+script:
+  - git submodule init
+  - git submodule update
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_CXX_COMPILER=$COMPILER .. && make


### PR DESCRIPTION
Adding Travis-CI support will greatly improve the stability of the repository. Although it will require regular updates when things change (such as compiler versions), at least we'll know when there are problems on Linux side. I plan to add tests for OSX and a few different compiler versions (help on this is welcome). Also plan to add testing for Vulkan at a later stage.

Here's the current build status on the fork:

![](https://travis-ci.org/samaursa/bgfx.cmake.svg?branch=master)