### PR TITLE
fixing build of tools for MinGW

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -29,8 +29,8 @@ endif()
 # Create the bx target
 add_library( bx STATIC ${BX_SOURCES} )
 
-# Link against psapi in Visual Studio
-if( MSVC )
+# Link against psapi on Windows
+if( WIN32 )
 	target_link_libraries( bx PUBLIC psapi )
 endif()
 


### PR DESCRIPTION
otherwise I would get the following error when linking shaderc.exe

> ../../../../bin/gcc/Release/libbx.a(os.cpp.obj):os.cpp:(.text+0x49): undefined reference to `GetProcessMemoryInfo'

Note: I'm using MinGW-w64 gcc 7.1 and also have VS 2017 installed with the Game development with C++ workflow