### PR TITLE
not removing the egl/ppapi gles2 contexts

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -66,8 +66,6 @@ endif()
 
 # Excluded files from compilation
 set_source_files_properties( ${BGFX_DIR}/src/amalgamated.mm PROPERTIES HEADER_FILE_ONLY ON )
-set_source_files_properties( ${BGFX_DIR}/src/glcontext_ppapi.cpp PROPERTIES HEADER_FILE_ONLY ON )
-set_source_files_properties( ${BGFX_DIR}/src/glcontext_egl.cpp PROPERTIES HEADER_FILE_ONLY ON )
 
 # Exclude mm files if not on OS X
 if( NOT APPLE )


### PR DESCRIPTION
the egl context is required when building with emscripten for asm.js - and the contents of the 2 files are ifdef-ed anyway so there is no problem in compiling them for platforms which don't need them.