### PR TITLE
Improved a bit shaderc

### DIFF
--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -140,15 +140,19 @@ endfunction()
 # shaderc( FILE file OUTPUT file ... )
 # See shaderc_parse() below for inputs
 function( shaderc )
-	cmake_parse_arguments( ARG "" "FILE;OUTPUT" "" ${ARGN} )
-	shaderc_parse( CLI ${ARGN} )
+	cmake_parse_arguments( ARG "" "FILE;OUTPUT;LABEL" "" ${ARGN} )
+	set( LABEL "" )
+	if( ARG_LABEL )
+		set( LABEL " (${ARG_LABEL})" )
+	endif()
+	shaderc_parse( CLI FILE ${ARG_FILE} OUTPUT ${ARG_OUTPUT} ${ARG_UNPARSED_ARGUMENTS} )
 	get_filename_component( OUTDIR "${ARG_OUTPUT}" ABSOLUTE )
 	get_filename_component( OUTDIR "${OUTDIR}" DIRECTORY )
 	add_custom_command( OUTPUT ${ARG_OUTPUT}
 		COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTDIR}"
 		COMMAND "$<TARGET_FILE:shaderc>" ${CLI}
 		MAIN_DEPENDENCY ${ARG_FILE}
-		COMMENT "Compiling shader ${ARG_FILE}"
+		COMMENT "Compiling shader ${ARG_FILE}${LABEL}"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 	)
 endfunction()

--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -142,7 +142,15 @@ endfunction()
 function( shaderc )
 	cmake_parse_arguments( ARG "" "FILE;OUTPUT" "" ${ARGN} )
 	shaderc_parse( CLI ${ARGN} )
-	add_custom_command( OUTPUT ${ARG_OUTPUT} COMMAND "$<TARGET_FILE:shaderc>" ${CLI} MAIN_DEPENDENCY ${ARG_FILE} COMMENT "Compiling shader ${ARG_FILE}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+	get_filename_component( OUTDIR "${ARG_OUTPUT}" ABSOLUTE )
+	get_filename_component( OUTDIR "${OUTDIR}" DIRECTORY )
+	add_custom_command( OUTPUT ${ARG_OUTPUT}
+		COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTDIR}"
+		COMMAND "$<TARGET_FILE:shaderc>" ${CLI}
+		MAIN_DEPENDENCY ${ARG_FILE}
+		COMMENT "Compiling shader ${ARG_FILE}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+	)
 endfunction()
 
 # shaderc_parse(


### PR DESCRIPTION
This PR adds two features:

1. when invoking `shaderc`, the folder containing the output will be created (I was tired of creating the folder manually, since git does not retain empty folders).
2. `shaderc` now accept a `LABEL` argument that is appended to the compilation message. It is very useful when a shader is compiled for several APIs for example, so instead of seeing:

        Compiling shader plop.vsh
        Compiling shader plop.vsh
        Compiling shader plop.vsh
   You can see:

        Compiling shader plop.vsh (DirectX11)
        Compiling shader plop.vsh (OpenGL2)
        Compiling shader plop.vsh (BananaRenderer)
   By default, not specifying `LABEL` will give the old behavior

And again, thanks for this repo !