### PR TITLE
Fixed: Enable DEBUG/CHECK/TRACE builds of bgfx wasn't actually working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option( BGFX_CUSTOM_TARGETS   "Include convenience custom targets."           ON
 option( BGFX_USE_OVR          "Build with OVR support."                       OFF )
 option( BGFX_AMALGAMATED      "Amalgamated bgfx build for faster compilation" OFF )
 option( BX_AMALGAMATED        "Amalgamated bx build for faster compilation"   OFF )
+option( BGFX_CONFIG_DEBUG   	  "Enables debug configuration on all builds" OFF)
 
 if( NOT BX_DIR )
 	set( BX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bx" CACHE STRING "Location of bx." )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,7 @@ if( BGFX_BUILD_TOOLS )
 	include( cmake/tools.cmake )
 endif()
 
-if( BGFX_BUILD_EXAMPLES )
-	include( cmake/examples.cmake )
-endif()
+include( cmake/examples.cmake )
 
 if( BGFX_INSTALL )
 	# install bx

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -35,6 +35,9 @@ add_library( bgfx STATIC ${BGFX_SOURCES} )
 
 # Enable BGFX_CONFIG_DEBUG in Debug configuration
 target_compile_definitions( bgfx PRIVATE "$<$<CONFIG:Debug>:BGFX_CONFIG_DEBUG=1>" )
+if(BGFX_CONFIG_DEBUG)
+	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_DEBUG=1)
+endif()
 
 # Special Visual Studio Flags
 if( MSVC )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -16,6 +16,7 @@ endif()
 
 # Grab the bx source files
 file( GLOB BX_SOURCES ${BX_DIR}/src/*.cpp )
+
 if(BX_AMALGAMATED)
 	set(BX_NOBUILD ${BX_SOURCES})
 	list(REMOVE_ITEM BX_NOBUILD ${BX_DIR}/src/amalgamated.cpp)
@@ -50,6 +51,11 @@ endif()
 target_compile_definitions( bx PUBLIC "__STDC_LIMIT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_FORMAT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_CONSTANT_MACROS" )
+
+target_compile_definitions( bx PRIVATE "$<$<CONFIG:Debug>:BX_CONFIG_DEBUG=1>" )
+if(BGFX_CONFIG_DEBUG)
+	target_compile_definitions( bx PRIVATE BX_CONFIG_DEBUG=1)
+endif()
 
 # Additional dependencies on Unix
 if( UNIX AND NOT APPLE )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -35,7 +35,7 @@ if( WIN32 )
 endif()
 
 # Add include directory of bx
-target_include_directories( bx PUBLIC ${BX_DIR}/include )
+target_include_directories( bx PUBLIC ${BX_DIR}/include ${BX_DIR}/3rdparty )
 
 # Build system specific configurations
 if( MSVC )

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -156,48 +156,51 @@ add_example(
 	${BGFX_DIR}/examples/common/ps
 )
 
-# Add examples
-set(
-	BGFX_EXAMPLES
-	00-helloworld
-	01-cubes
-	02-metaballs
-	03-raymarch
-	04-mesh
-	05-instancing
-	06-bump
-	07-callback
-	08-update
-	09-hdr
-	10-font
-	11-fontsdf
-	12-lod
-	13-stencil
-	14-shadowvolumes
-	15-shadowmaps-simple
-	16-shadowmaps
-	17-drawstress
-	18-ibl
-	19-oit
-	20-nanovg
-	21-deferred
-	22-windows
-	23-vectordisplay
-	24-nbody
-	25-c99
-	26-occlusion
-	27-terrain
-	28-wireframe
-	29-debugdraw
-	30-picking
-	31-rsm
-	32-particles
-	33-pom
-	34-mvs
-	35-dynamic
-	36-sky
-)
+# Only add examples if set, otherwise we still need exmaples common for tools
+if( BGFX_BUILD_EXAMPLES )
+    # Add examples
+    set(
+        BGFX_EXAMPLES
+        00-helloworld
+        01-cubes
+        02-metaballs
+        03-raymarch
+        04-mesh
+        05-instancing
+        06-bump
+        07-callback
+        08-update
+        09-hdr
+        10-font
+        11-fontsdf
+        12-lod
+        13-stencil
+        14-shadowvolumes
+        15-shadowmaps-simple
+        16-shadowmaps
+        17-drawstress
+        18-ibl
+        19-oit
+        20-nanovg
+        21-deferred
+        22-windows
+        23-vectordisplay
+        24-nbody
+        25-c99
+        26-occlusion
+        27-terrain
+        28-wireframe
+        29-debugdraw
+        30-picking
+        31-rsm
+        32-particles
+        33-pom
+        34-mvs
+        35-dynamic
+        36-sky
+    )
 
-foreach( EXAMPLE ${BGFX_EXAMPLES} )
-	add_example( ${EXAMPLE} )
-endforeach()
+    foreach( EXAMPLE ${BGFX_EXAMPLES} )
+        add_example( ${EXAMPLE} )
+    endforeach()
+endif()


### PR DESCRIPTION
Debug/CHECK builds of bgfx were not straightforward with the current setup; bgfx relies on BX also being debug-enabled, while this only enabled it for BGFX and only in CMAKE Debug mode. You actually have to enable BX_TRACE in both bgfx and bx to actually get trace working. This was only adding it to bgfx, and only with CMAKE_BUILD_TYPE=Debug.

I Added BGFX_CONFIG_DEBUG cmake option to easily enable checked/trace builds in release mode so you don't get the overhead. 