### PR TITLE
Fix build errors when supplying relative paths to BX_DIR, BIMG_DIR and BGFX_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,18 @@ option( BGFX_USE_DEBUG_SUFFIX "Add 'd' suffix to debug output targets"        ON
 
 if( NOT BX_DIR )
 	set( BX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bx" CACHE STRING "Location of bx." )
+elseif( NOT IS_ABSOLUTE "${BX_DIR}")
+	get_filename_component(BX_DIR "${BX_DIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 if( NOT BIMG_DIR )
 	set( BIMG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bimg" CACHE STRING "Location of bimg." )
+elseif( NOT IS_ABSOLUTE "${BIMG_DIR}")
+	get_filename_component(BIMG_DIR "${BIMG_DIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 if( NOT BGFX_DIR )
 	set( BGFX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bgfx" CACHE STRING "Location of bgfx." )
+elseif( NOT IS_ABSOLUTE "${BGFX_DIR}")
+	get_filename_component(BGFX_DIR "${BGFX_DIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 if( BGFX_USE_OVR )


### PR DESCRIPTION
Previously, relative paths supplied to these variables caused build errors as they remained relative even when the current directory changed (e.g when building things in `generated/`).

This PR fixes that issue by rendering those paths absolute as soon as possible in `CMakeLists.txt`.