### PR TITLE
Add build output files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 build/
 *.swp
+CMakeCache.txt
+CMakeFiles/
+Debug/
+Release/
+*.vcxproj
+*.vcxproj.filters
+*.dir/
+*.sln
+install/
+install_manifest.txt
+generated/
+cmake_install.cmake


### PR DESCRIPTION
I know you're *supposed* to build in the `build/` folder, but it's always nice to ignore those files in the root too. My current (rather primitive) build system builds CMake deps in their root.

While this change is useful to me, I understand if it doesn't get merged. I have my own fork with everything I need so I'm just contributing my changes upstream.