### PR TITLE
Add iOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required( VERSION 3.0 )
 project( bgfx )
 
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
-if( APPLE )
+if( APPLE AND NOT IOS )
 	set( CMAKE_CXX_FLAGS "-ObjC++ --std=c++14" )
 elseif(UNIX)
     set(CMAKE_CXX_STANDARD 14)

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -60,8 +60,10 @@ if( BGFX_USE_OVR )
 	target_link_libraries( bgfx PUBLIC ovr )
 endif()
 
-# Frameworks required on OS X
-if( APPLE )
+# Frameworks required on iOS and macOS
+if( IOS )
+	target_link_libraries (bgfx PUBLIC "-framework OpenGLES  -framework Metal -framework UIKit -framework CoreGraphics -framework QuartzCore")
+elseif( APPLE )
 	find_library( COCOA_LIBRARY Cocoa )
 	find_library( METAL_LIBRARY Metal )
 	find_library( QUARTZCORE_LIBRARY QuartzCore )

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -130,6 +130,10 @@ function( add_example ARG_NAME )
 		if( BGFX_CUSTOM_TARGETS )
 			add_dependencies( examples example-${ARG_NAME} )
 		endif()
+		if( IOS )
+			set_target_properties(example-${ARG_NAME} PROPERTIES MACOSX_BUNDLE ON
+													  MACOSX_BUNDLE_GUI_IDENTIFIER example-${ARG_NAME})
+		endif()
 	endif()
 	target_compile_definitions( example-${ARG_NAME} PRIVATE "-D_CRT_SECURE_NO_WARNINGS" "-D__STDC_FORMAT_MACROS" "-DENTRY_CONFIG_IMPLEMENT_MAIN=1" )
 

--- a/cmake/shared.cmake
+++ b/cmake/shared.cmake
@@ -25,7 +25,7 @@ target_include_directories( bgfx-bounds INTERFACE ${BGFX_DIR}/include )
 target_include_directories( bgfx-bounds INTERFACE ${BGFX_DIR}/examples/common )
 
 # Frameworks required on OS X
-if( APPLE )
+if( APPLE AND NOT IOS)
 	find_library( COCOA_LIBRARY Cocoa )
 	mark_as_advanced( COCOA_LIBRARY )
 	target_link_libraries( bgfx-vertexdecl INTERFACE ${COCOA_LIBRARY} )

--- a/cmake/toolchains/iOS.toolchain.cmake
+++ b/cmake/toolchains/iOS.toolchain.cmake
@@ -1,0 +1,152 @@
+# Copyright (c) 2016, Bogdan Cristea <cristeab@gmail.com>
+# Modified work Copyright (c) 2018, Jonny Paton
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is based off of the Platform/Darwin.cmake and Platform/UnixPaths.cmake
+# files which are included with CMake 2.8.4
+# It has been altered for iOS development
+
+# Options:
+#
+# IOS_DEVELOPER_ROOT = automatic(default) or /path/to/platform/Developer folder
+#   If set manually, it will override the default location and force the user of a particular Developer Platform
+#
+# IOS_SDK_ROOT = automatic(default) or /path/to/platform/Developer/SDKs/SDK folder
+#   By default this location is automatcially chosen based on the IOS_DEVELOPER_ROOT value.
+#   In this case it will always be the most up-to-date SDK found in the IOS_DEVELOPER_ROOT path.
+#   If set manually, this will force the use of a specific SDK version
+
+# Macros:
+#
+# set_xcode_property (TARGET XCODE_PROPERTY XCODE_VALUE)
+#  A convenience macro for setting xcode specific properties on targets
+#  example: set_xcode_property (myioslib IPHONEOS_DEPLOYMENT_TARGET "3.1")
+#
+# find_host_package (PROGRAM ARGS)
+#  A macro used to find executable programs on the host system, not within the iOS environment.
+#  Thanks to the android-cmake project for providing the command
+
+# Standard settings
+set (CMAKE_SYSTEM_NAME Darwin)
+set (CMAKE_SYSTEM_VERSION 1)
+set (UNIX True)
+set (APPLE True)
+set (IOS True)
+
+# Required as of cmake 2.8.10
+set (CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+
+# Determine the cmake host system version so we know where to find the iOS SDKs
+find_program (CMAKE_UNAME uname /bin /usr/bin /usr/local/bin)
+if (CMAKE_UNAME)
+	exec_program(uname ARGS -r OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_VERSION)
+	string (REGEX REPLACE "^([0-9]+)\\.([0-9]+).*$" "\\1" DARWIN_MAJOR_VERSION "${CMAKE_HOST_SYSTEM_VERSION}")
+endif (CMAKE_UNAME)
+
+set(CMAKE_C_COMPILER /usr/bin/clang CACHE FILEPATH "" FORCE)
+set(CMAKE_CXX_COMPILER /usr/bin/clang++ CACHE FILEPATH "" FORCE)
+set(CMAKE_AR ar CACHE FILEPATH "" FORCE)
+
+# Skip the platform compiler checks for cross compiling
+set (CMAKE_CXX_COMPILER_WORKS TRUE)
+set (CMAKE_C_COMPILER_WORKS TRUE)
+
+# All iOS/Darwin specific settings - some may be redundant
+set (CMAKE_SHARED_LIBRARY_PREFIX "lib")
+set (CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
+set (CMAKE_SHARED_MODULE_PREFIX "lib")
+set (CMAKE_SHARED_MODULE_SUFFIX ".so")
+set (CMAKE_MODULE_EXISTS 1)
+set (CMAKE_DL_LIBS "")
+
+set (CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG "-compatibility_version ")
+set (CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
+set (CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
+set (CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
+
+# Hidden visibilty is required for cxx on iOS 
+set (CMAKE_C_FLAGS_INIT "")
+set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden")
+
+set (CMAKE_C_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_C_LINK_FLAGS}")
+set (CMAKE_CXX_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_CXX_LINK_FLAGS}")
+
+set (CMAKE_PLATFORM_HAS_INSTALLNAME 1)
+set (CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-dynamiclib -headerpad_max_install_names")
+set (CMAKE_SHARED_MODULE_CREATE_C_FLAGS "-bundle -headerpad_max_install_names")
+set (CMAKE_SHARED_MODULE_LOADER_C_FLAG "-Wl,-bundle_loader,")
+set (CMAKE_SHARED_MODULE_LOADER_CXX_FLAG "-Wl,-bundle_loader,")
+set (CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+
+# hack: if a new cmake (which uses CMAKE_INSTALL_NAME_TOOL) runs on an old build tree
+# (where install_name_tool was hardcoded) and where CMAKE_INSTALL_NAME_TOOL isn't in the cache
+# and still cmake didn't fail in CMakeFindBinUtils.cmake (because it isn't rerun)
+# hardcode CMAKE_INSTALL_NAME_TOOL here to install_name_tool, so it behaves as it did before, Alex
+if (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
+	find_program(CMAKE_INSTALL_NAME_TOOL install_name_tool)
+endif (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
+
+# Setup iOS developer location unless specified manually with IOS_DEVELOPER_ROOT
+exec_program(/usr/bin/xcode-select ARGS -print-path OUTPUT_VARIABLE XCODE_DEVELOPER_DIR)
+set (IOS_DEVELOPER_ROOT "${XCODE_DEVELOPER_DIR}/Platforms/iPhoneOS.platform/Developer" CACHE PATH "Location of iOS Platform")
+
+# Find and use the most recent iOS sdk unless specified manually with IOS_SDK_ROOT
+if (NOT DEFINED IOS_SDK_ROOT)
+    file (GLOB _IOS_SDKS "${IOS_DEVELOPER_ROOT}/SDKs/*")
+    if (_IOS_SDKS)
+        list (SORT _IOS_SDKS)
+        list (REVERSE _IOS_SDKS)
+        list (GET _IOS_SDKS 0 IOS_SDK_ROOT)
+    else (_IOS_SDKS)
+        message (FATAL_ERROR "No iOS SDK's found in default search path ${IOS_DEVELOPER_ROOT}. Manually set IOS_SDK_ROOT or install the iOS SDK.")
+    endif (_IOS_SDKS)
+    message (STATUS "Toolchain using default iOS SDK: ${IOS_SDK_ROOT}")
+endif (NOT DEFINED IOS_SDK_ROOT)
+set (IOS_SDK_ROOT ${IOS_SDK_ROOT} CACHE PATH "Location of the selected iOS SDK")
+
+# Set the sysroot default to the most recent SDK
+set (CMAKE_OSX_SYSROOT ${IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS support")
+
+# Set the find root to the iOS developer roots and to user defined paths
+set (CMAKE_FIND_ROOT_PATH ${IOS_DEVELOPER_ROOT} ${IOS_SDK_ROOT} ${CMAKE_PREFIX_PATH} CACHE STRING "iOS find search path root")
+
+# default to searching for frameworks first
+set (CMAKE_FIND_FRAMEWORK FIRST)
+
+# set up the default search directories for frameworks
+set (CMAKE_SYSTEM_FRAMEWORK_PATH
+    ${IOS_SDK_ROOT}/System/Library/Frameworks
+    ${IOS_SDK_ROOT}/System/Library/PrivateFrameworks
+    ${IOS_SDK_ROOT}/Developer/Library/Frameworks
+)
+
+# only search the iOS sdks, not the remainder of the host filesystem
+set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
+set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+
+# This macro lets you find executable programs on the host system
+macro (find_host_package)
+	set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+	set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
+	set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
+	set (IOS FALSE)
+
+	find_package(${ARGN})
+
+	set (IOS TRUE)
+	set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
+	set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+	set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endmacro (find_host_package)

--- a/cmake/tools/geometryc.cmake
+++ b/cmake/tools/geometryc.cmake
@@ -20,3 +20,8 @@ target_link_libraries( geometryc bx bgfx-bounds bgfx-vertexdecl forsyth-too ib-c
 if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools geometryc )
 endif()
+
+if (IOS)
+	set_target_properties(geometryc PROPERTIES MACOSX_BUNDLE ON
+											   MACOSX_BUNDLE_GUI_IDENTIFIER example-${ARG_NAME})
+endif()

--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -22,6 +22,11 @@ if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools shaderc )
 endif()
 
+if (IOS)
+	set_target_properties(shaderc PROPERTIES MACOSX_BUNDLE ON
+											 MACOSX_BUNDLE_GUI_IDENTIFIER shaderc)
+endif()
+
 function( add_shader ARG_FILE )
 	# Parse arguments
 	cmake_parse_arguments( ARG "FRAGMENT;VERTEX" "OUTPUT;GLSL_VERSION;DX9_MODEL;DX11_MODEL" "PLATFORMS" ${ARGN} )

--- a/cmake/tools/texturec.cmake
+++ b/cmake/tools/texturec.cmake
@@ -16,3 +16,8 @@ target_link_libraries( texturec bimg )
 if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools texturec )
 endif()
+
+if (IOS)
+	set_target_properties(texturec PROPERTIES MACOSX_BUNDLE ON
+											  MACOSX_BUNDLE_GUI_IDENTIFIER texturec)
+endif()

--- a/cmake/tools/texturev.cmake
+++ b/cmake/tools/texturev.cmake
@@ -16,3 +16,8 @@ target_link_libraries( texturev example-common )
 if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools texturev )
 endif()
+
+if (IOS)
+	set_target_properties(texturev PROPERTIES MACOSX_BUNDLE ON
+										      MACOSX_BUNDLE_GUI_IDENTIFIER texturev)
+endif()


### PR DESCRIPTION
I've been using this a lot in one of my projects (thanks!) and have needed iOS support. With these changes you can build the demos for iOS (simulator or device)

To build just set CMAKE_TOOLCHAIN_FILE to cmake/toolchains/iOS.toolchain.cmake