### PR TITLE
Option to specify minimum opengl version at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option( BGFX_AMALGAMATED      "Amalgamated bgfx build for faster compilation" OF
 option( BX_AMALGAMATED        "Amalgamated bx build for faster compilation"   OFF )
 option( BGFX_CONFIG_DEBUG     "Enables debug configuration on all builds"     OFF )
 option( BGFX_USE_DEBUG_SUFFIX "Add 'd' suffix to debug output targets"        ON  )
+set( BGFX_OPENGL_VERSION  "" CACHE STRING "Specify minimum opengl version" )
 
 if( NOT BX_DIR )
 	set( BX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bx" CACHE STRING "Location of bx." )

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -43,6 +43,10 @@ if(BGFX_CONFIG_DEBUG)
 	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_DEBUG=1)
 endif()
 
+if( NOT ${BGFX_OPENGL_VERSION} STREQUAL "" )
+	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGL=${BGFX_OPENGL_VERSION})
+endif()
+
 # Special Visual Studio Flags
 if( MSVC )
 	target_compile_definitions( bgfx PRIVATE "_CRT_SECURE_NO_WARNINGS" )


### PR DESCRIPTION
This small fix allows to specify BGFX_CONFIG_RENDERER_OPENGL from Cmake command line

If not set, it reverts to default behaviour