### PR TITLE
Updates for emscripten, along with travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,18 @@ matrix:
     env:
       - AMALGAMATED=ON
 
+  - name: "Emscripten"
+    os: linux
+    dist: xenial
+    language: node_js
+    services:
+      - docker
+    before_script: 
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
+    script:
+      - docker exec -it emscripten emconfigure cmake . -DBGFX_BUILD_TOOLS=OFF
+      - docker exec -it emscripten emmake make
+
 script:
   - mkdir build && cd build
   - cmake $CMAKE_FLAGS -DBGFX_INSTALL_EXAMPLES=ON -DBGFX_AMALGAMATED=$AMALGAMATED -DBX_AMALGAMATED=$AMALGAMATED ..

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -143,11 +143,18 @@ function( add_example ARG_NAME )
 	target_compile_definitions( example-${ARG_NAME} PRIVATE "-D_CRT_SECURE_NO_WARNINGS" "-D__STDC_FORMAT_MACROS" "-DENTRY_CONFIG_IMPLEMENT_MAIN=1" )
 
 	# Configure shaders
-	if( NOT ARG_COMMON )
+	if( NOT ARG_COMMON AND NOT IOS AND NOT EMSCRIPTEN)
 		foreach( SHADER ${SHADERS} )
 			add_bgfx_shader( ${SHADER} ${ARG_NAME} )
 		endforeach()
 		source_group( "Shader Files" FILES ${SHADERS})
+	endif()
+
+	if (NOT ARG_COMMON AND EMSCRIPTEN)
+		target_link_libraries(example-${ARG_NAME}
+			"-s PRECISE_F32=1"
+			"-s TOTAL_MEMORY=268435456"
+			"--memory-init-file 1")
 	endif()
 
 	# Directory name


### PR DESCRIPTION
This adds the missing flags to get the examples working with emscripten, and a travis build job to build it.