### PR TITLE
Android support and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,65 @@ matrix:
     before_script: 
       - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
     script:
-      - docker exec -it emscripten emconfigure cmake . -DBGFX_BUILD_TOOLS=OFF
+      - docker exec -it emscripten emconfigure cmake . -DBGFX_BUILD_TOOLS=OFF -DBGFX_AMALGAMATED=$AMALGAMATED -DBX_AMALGAMATED=$AMALGAMATED
       - docker exec -it emscripten emmake make
+    env:
+      - AMALGAMATED=OFF
+
+  - name: "Emscripten Amalgamated"
+    os: linux
+    dist: xenial
+    language: node_js
+    services:
+      - docker
+    before_script: 
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
+    script:
+      - docker exec -it emscripten emconfigure cmake . -DBGFX_BUILD_TOOLS=OFF -DBGFX_AMALGAMATED=$AMALGAMATED -DBX_AMALGAMATED=$AMALGAMATED
+      - docker exec -it emscripten emmake make
+    env:
+      - AMALGAMATED=OFF
+
+  - name: "Android armeabi-v7a"
+    language: android
+    android: &androidComponents
+      components:
+        - tools
+        - platform-tools
+        - build-tools-26.0.1
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+      - AMALGAMATED=OFF
+    install: &androidInstall
+      - echo y | sdkmanager "cmake;3.10.2.4988404" 
+      - echo y | sdkmanager "lldb;3.1"
+      - sudo ln -sf /usr/local/android-sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
+      - wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
+      - unzip -qq android-ndk-r18b-linux-x86_64.zip
+
+  - name: "Android armeabi-v7a Amalgamated"
+    language: android
+    android: *androidComponents
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+      - AMALGAMATED=ON
+    install: *androidInstall
+
+  - name: "Android x86"
+    language: android
+    android: *androidComponents
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+      - AMALGAMATED=OFF
+    install: *androidInstall
+
+  - name: "Android x86 Amalgamated"
+    language: android
+    android: *androidComponents
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+      - AMALGAMATED=ON
+    install: *androidInstall
 
 script:
   - mkdir build && cd build

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -77,7 +77,7 @@ elseif( APPLE )
 	target_link_libraries( bgfx PUBLIC ${COCOA_LIBRARY} ${METAL_LIBRARY} ${QUARTZCORE_LIBRARY} )
 endif()
 
-if( UNIX AND NOT APPLE AND NOT EMSCRIPTEN )
+if( UNIX AND NOT APPLE AND NOT EMSCRIPTEN AND NOT ANDROID )
 	find_package(X11 REQUIRED)
 	find_package(OpenGL REQUIRED)
 	#The following commented libraries are linked by bx

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -58,7 +58,7 @@ if(BGFX_CONFIG_DEBUG)
 endif()
 
 # Additional dependencies on Unix
-if( UNIX AND NOT APPLE )
+if( UNIX AND NOT APPLE AND NOT ANDROID )
 	# Threads
 	find_package( Threads )
 	target_link_libraries( bx ${CMAKE_THREAD_LIBS_INIT} dl )

--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -25,7 +25,9 @@ if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools shaderc )
 endif()
 
-if (IOS)
+if (ANDROID)
+	target_link_libraries( shaderc log )
+elseif (IOS)
 	set_target_properties(shaderc PROPERTIES MACOSX_BUNDLE ON
 											 MACOSX_BUNDLE_GUI_IDENTIFIER shaderc)
 endif()

--- a/cmake/tools/texturec.cmake
+++ b/cmake/tools/texturec.cmake
@@ -17,7 +17,9 @@ if( BGFX_CUSTOM_TARGETS )
 	add_dependencies( tools texturec )
 endif()
 
-if (IOS)
+if (ANDROID)
+	target_link_libraries( texturec log )
+elseif (IOS)
 	set_target_properties(texturec PROPERTIES MACOSX_BUNDLE ON
 											  MACOSX_BUNDLE_GUI_IDENTIFIER texturec)
 endif()


### PR DESCRIPTION
This fixes some of the cmake issues when trying to build for android, and adds x86 and armeabiv7 builds to the CI.

Using API version 26, purely because that's what I've tested with. Have got the tools and examples disabled for now, because I've struggled to get them working (mainly because I find android to be a struggle at the best of times!)