### PR TITLE
Add EXPORT to install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,22 +64,46 @@ endif()
 include( cmake/examples.cmake )
 
 if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+
 	# install bx
-	install( TARGETS bx DESTINATION lib )
+	install( TARGETS bx
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 	install( DIRECTORY ${BX_DIR}/include DESTINATION . )
 
 	# install bimg
-	install( TARGETS bimg DESTINATION lib )
+	install( TARGETS bimg
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 	install( DIRECTORY ${BIMG_DIR}/include DESTINATION . )
 
 	# install bgfx
-	install( TARGETS bgfx DESTINATION lib )
+	install( TARGETS bgfx
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 	install( DIRECTORY ${BGFX_DIR}/include DESTINATION . )
+
+	# install export
+	install(
+		EXPORT bgfx-config
+		NAMESPACE bgfx::
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bgfx)
 
 	# install tools
 	if( BGFX_BUILD_TOOLS )
-        install( TARGETS shaderc DESTINATION bin )
-		install( TARGETS geometryc DESTINATION bin )
+		install( TARGETS shaderc
+			EXPORT bgfx-config
+			DESTINATION bin )
+		install( TARGETS geometryc
+			EXPORT bgfx-config
+			DESTINATION bin )
+		install( TARGETS texturec
+			EXPORT bgfx-config
+			DESTINATION bin )
+		install( TARGETS texturev
+			EXPORT bgfx-config
+			DESTINATION bin )
 	endif()
 
 	# install examples

--- a/cmake/3rdparty/astc-codec.cmake
+++ b/cmake/3rdparty/astc-codec.cmake
@@ -20,5 +20,15 @@ file(
 )
 
 add_library( astc-codec STATIC ${ASTC_CODEC_SOURCES} )
-target_include_directories( astc-codec PUBLIC ${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/astc-codec ${BIMG_DIR}/3rdparty/astc-codec/include )
+target_include_directories( astc-codec
+	PUBLIC
+	$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/astc-codec ${BIMG_DIR}/3rdparty/astc-codec/include>)
 set_target_properties( astc-codec PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS astc-codec
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/astc.cmake
+++ b/cmake/3rdparty/astc.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB ASTC_SOURCES ${BIMG_DIR}/3rdparty/astc/*.cpp ${BIMG_DIR}/3rdparty/astc/*.h )
 
 add_library( astc STATIC ${ASTC_SOURCES} )
-target_include_directories( astc PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( astc PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( astc PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS astc
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/edtaa3.cmake
+++ b/cmake/3rdparty/edtaa3.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB EDTAA3_SOURCES ${BIMG_DIR}/3rdparty/edtaa3/*.cpp ${BIMG_DIR}/3rdparty/edtaa3/*.h )
 
 add_library( edtaa3 STATIC ${EDTAA3_SOURCES} )
-target_include_directories( edtaa3 PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( edtaa3 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( edtaa3 PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS edtaa3
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/etc1.cmake
+++ b/cmake/3rdparty/etc1.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB ETC1_SOURCES ${BIMG_DIR}/3rdparty/etc1/*.cpp ${BIMG_DIR}/3rdparty/etc1/*.h )
 
 add_library( etc1 STATIC ${ETC1_SOURCES} )
-target_include_directories( etc1 PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( etc1 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( etc1 PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS etc1
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/etc2.cmake
+++ b/cmake/3rdparty/etc2.cmake
@@ -15,6 +15,14 @@ endif()
 file( GLOB ETC2_SOURCES ${BIMG_DIR}/3rdparty/etc2/*.cpp ${BIMG_DIR}/3rdparty/etc2/*.h )
 
 add_library( etc2 STATIC ${ETC2_SOURCES} )
-target_include_directories( etc2 PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( etc2 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( etc2 PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( etc2 PUBLIC bx )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS etc2
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/iqa.cmake
+++ b/cmake/3rdparty/iqa.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB IQA_SOURCES ${BIMG_DIR}/3rdparty/iqa/source/*.c ${BIMG_DIR}/3rdparty/iqa/include/*.h )
 
 add_library( iqa STATIC ${IQA_SOURCES} )
-target_include_directories( iqa PUBLIC ${BIMG_DIR}/3rdparty/iqa/include )
+target_include_directories( iqa PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/iqa/include> )
 set_target_properties( iqa PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS iqa
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/libsquish.cmake
+++ b/cmake/3rdparty/libsquish.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB SQUISH_SOURCES ${BIMG_DIR}/3rdparty/libsquish/*.cpp ${BIMG_DIR}/3rdparty/libsquish/*.h ${BIMG_DIR}/3rdparty/libsquish/*.inl )
 
 add_library( squish STATIC ${SQUISH_SOURCES} )
-target_include_directories( squish PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( squish PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( squish PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS squish
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/nvtt.cmake
+++ b/cmake/3rdparty/nvtt.cmake
@@ -28,6 +28,14 @@ file(
 )
 
 add_library( nvtt STATIC ${NVTT_SOURCES} )
-target_include_directories( nvtt PUBLIC ${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/nvtt )
+target_include_directories( nvtt PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/nvtt> )
 set_target_properties( nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( nvtt PUBLIC bx )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS nvtt
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/3rdparty/pvrtc.cmake
+++ b/cmake/3rdparty/pvrtc.cmake
@@ -15,5 +15,13 @@ endif()
 file( GLOB PVRTC_SOURCES ${BIMG_DIR}/3rdparty/pvrtc/*.cpp ${BIMG_DIR}/3rdparty/pvrtc/*.h )
 
 add_library( pvrtc STATIC ${PVRTC_SOURCES} )
-target_include_directories( pvrtc PUBLIC ${BIMG_DIR}/3rdparty )
+target_include_directories( pvrtc PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( pvrtc PROPERTIES FOLDER "bgfx/3rdparty" )
+
+if( BGFX_INSTALL )
+	include(GNUInstallDirs)
+	install(
+		TARGETS pvrtc
+		EXPORT bgfx-config
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -53,8 +53,14 @@ if( MSVC )
 endif()
 
 # Includes
-target_include_directories( bgfx PRIVATE ${BGFX_DIR}/3rdparty ${BGFX_DIR}/3rdparty/dxsdk/include ${BGFX_DIR}/3rdparty/khronos )
-target_include_directories( bgfx PUBLIC ${BGFX_DIR}/include )
+target_include_directories( bgfx
+	PRIVATE
+		${BGFX_DIR}/3rdparty
+		${BGFX_DIR}/3rdparty/dxsdk/include
+		${BGFX_DIR}/3rdparty/khronos
+	PUBLIC
+		$<BUILD_INTERFACE:${BGFX_DIR}/include>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # bgfx depends on bx and bimg
 target_link_libraries( bgfx PUBLIC bx bimg )

--- a/cmake/bimg.cmake
+++ b/cmake/bimg.cmake
@@ -32,7 +32,10 @@ file( GLOB BIMG_SOURCES ${BIMG_DIR}/src/*.cpp )
 add_library( bimg STATIC ${BIMG_SOURCES} )
 
 # Add include directory of bimg
-target_include_directories( bimg PUBLIC ${BIMG_DIR}/include )
+target_include_directories( bimg
+	PUBLIC
+		$<BUILD_INTERFACE:${BIMG_DIR}/include>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # bimg dependencies
 target_link_libraries( bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt pvrtc )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -36,15 +36,18 @@ if( WIN32 )
 endif()
 
 # Add include directory of bx
-target_include_directories( bx PUBLIC ${BX_DIR}/include ${BX_DIR}/3rdparty )
+target_include_directories( bx
+	PUBLIC
+		$<BUILD_INTERFACE:${BX_DIR}/include/ ${BX_DIR}/include ${BX_DIR}/3rdparty>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Build system specific configurations
 if( MSVC )
-	target_include_directories( bx PUBLIC ${BX_DIR}/include/compat/msvc )
+	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc> )
 elseif( MINGW )
-	target_include_directories( bx PUBLIC ${BX_DIR}/include/compat/mingw )
+	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw> )
 elseif( APPLE )
-	target_include_directories( bx PUBLIC ${BX_DIR}/include/compat/osx )
+	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx> )
 endif()
 
 # All configurations


### PR DESCRIPTION
Add `EXPORT bgfx-config` with `bgfx::` namespace to auto generate a
`bgfx-config.cmake` file at install time (INSTALL on `visual studio` or `make
install` on MakeFile projects).
The file is for use with `find_package` and installs itself in the
lib directory under `cmake/bgfx/bgfx-config.cmake`.
If installed on a linux system, `find_package` will find this config
file without any configuration.
This config file allows dependent projects to use commands such as
linking with bgfx:
```
find_package(bgfx REQUIRED COMPONENTS bgfx)
target_link_libraries(dependent PUBLIC bgfx::bgfx)
```
or compiling a shader at build time:
```
find_package(bgfx REQUIRED COMPONENTS shaderc)
add_custom_command(OUTPUT compiled_shader.glsl
                   COMMAND
                       bgfx::shaderc
                       -f vs_input_shader.sc
                       -o compiled_shader.glsl
                       --type vertex)
```
Since the library is static, the 3rd parties need to also be part of the export group.
Paths marked with `BUILD_INTERFACE` are done so to be ignored by the install target which will not need them. In some cases they are accompanied by `INSTALL_INTERFACE`, this is to set a different include path at installation. e.g. `/usr/include` over `/home/.../project_path/include`