### PR TITLE
Use `configure_file` instead of `file WRITE` to write generated files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ Release/
 *.sln
 install/
 install_manifest.txt
-generated/
+generated/*
+!generated/*.in
 cmake_install.cmake

--- a/cmake/shared.cmake
+++ b/cmake/shared.cmake
@@ -9,17 +9,20 @@
 # this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 add_library( bgfx-vertexdecl INTERFACE )
-file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated/vertexdecl.cpp "#include \"${BGFX_DIR}/src/vertexdecl.cpp\"" )
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/generated/vertexdecl.cpp.in
+                ${CMAKE_CURRENT_BINARY_DIR}/generated/vertexdecl.cpp )
 target_sources( bgfx-vertexdecl INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/generated/vertexdecl.cpp )
 target_include_directories( bgfx-vertexdecl INTERFACE ${BGFX_DIR}/include )
 
 add_library( bgfx-shader-spirv INTERFACE )
-file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated/shader_spirv.cpp "#include \"${BGFX_DIR}/src/shader_spirv.cpp\"" )
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/generated/shader_spirv.cpp.in
+                ${CMAKE_CURRENT_BINARY_DIR}/generated/shader_spirv.cpp )
 target_sources( bgfx-shader-spirv INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/generated/shader_spirv.cpp )
 target_include_directories( bgfx-shader-spirv INTERFACE ${BGFX_DIR}/include )
 
 add_library( bgfx-bounds INTERFACE )
-file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated/bounds.cpp "#include \"${BGFX_DIR}/examples/common/bounds.cpp\"" )
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/generated/bounds.cpp.in
+                ${CMAKE_CURRENT_BINARY_DIR}/generated/bounds.cpp )
 target_sources( bgfx-bounds INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/generated/bounds.cpp )
 target_include_directories( bgfx-bounds INTERFACE ${BGFX_DIR}/include )
 target_include_directories( bgfx-bounds INTERFACE ${BGFX_DIR}/examples/common )

--- a/generated/bounds.cpp.in
+++ b/generated/bounds.cpp.in
@@ -1,0 +1,1 @@
+#include "@BGFX_DIR@/examples/common/bounds.cpp"

--- a/generated/shader_spirv.cpp.in
+++ b/generated/shader_spirv.cpp.in
@@ -1,0 +1,1 @@
+#include "@BGFX_DIR@/src/shader_spirv.cpp"

--- a/generated/vertexdecl.cpp.in
+++ b/generated/vertexdecl.cpp.in
@@ -1,0 +1,1 @@
+#include "@BGFX_DIR@/src/vertexdecl.cpp"


### PR DESCRIPTION
This ensures that running CMake will only result in the generated
files being overwritten if their contents will change. This is
important because these files are used as build inputs, and so every
time these files are written, their downstream dependants may be
marked as dirty during the build, and so downstream dependencies end
up needlessly re-building every time when `file WRITE` is used.

For example, if you're generating Makefiles and you're using the
convenient `add_shader` function to add shaderc build commands to your
build when shader sources change, this change prevents `shaderc` from
being needlessly re-linked (which often takes minutes) on the first
build after every CMake run.