### PR TITLE
include: Put BUILD_INTERFACE entries one per line

### DIFF
--- a/cmake/3rdparty/astc-codec.cmake
+++ b/cmake/3rdparty/astc-codec.cmake
@@ -22,7 +22,9 @@ file(
 add_library( astc-codec STATIC ${ASTC_CODEC_SOURCES} )
 target_include_directories( astc-codec
 	PUBLIC
-	$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/astc-codec ${BIMG_DIR}/3rdparty/astc-codec/include>)
+		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty>
+		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-codec>
+		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-codec/include> )
 set_target_properties( astc-codec PROPERTIES FOLDER "bgfx/3rdparty" )
 
 if( BGFX_INSTALL )

--- a/cmake/3rdparty/nvtt.cmake
+++ b/cmake/3rdparty/nvtt.cmake
@@ -28,7 +28,10 @@ file(
 )
 
 add_library( nvtt STATIC ${NVTT_SOURCES} )
-target_include_directories( nvtt PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty ${BIMG_DIR}/3rdparty/nvtt> )
+target_include_directories( nvtt
+	PUBLIC
+		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty>
+		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/nvtt> )
 set_target_properties( nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( nvtt PUBLIC bx )
 

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -38,7 +38,8 @@ endif()
 # Add include directory of bx
 target_include_directories( bx
 	PUBLIC
-		$<BUILD_INTERFACE:${BX_DIR}/include/ ${BX_DIR}/include ${BX_DIR}/3rdparty>
+		$<BUILD_INTERFACE:${BX_DIR}/include>
+		$<BUILD_INTERFACE:${BX_DIR}/3rdparty>
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Build system specific configurations


### PR DESCRIPTION
This fixes an error when adding subdirectory:
```
CMake Error in _deps/bgfx-src/CMakeLists.txt:
  Target "astc-codec" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "_deps/bgfx-src/"

  which is prefixed in the build directory.Target "astc-codec"
  INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "_deps/bgfx-src/"

  which is prefixed in the source directory.
```