### PR TITLE
Fixed that only 1 include was used by shaderc

### DIFF
--- a/cmake/tools/shaderc.cmake
+++ b/cmake/tools/shaderc.cmake
@@ -230,16 +230,10 @@ function( shaderc_parse ARG_OUT )
 
 	# -i
 	if( ARG_INCLUDES )
-		list( APPEND CLI "-i" )
-		set( INCLUDES "" )
 		foreach( INCLUDE ${ARG_INCLUDES} )
-			if( NOT "${INCLUDES}" STREQUAL "" )
-				set( INCLUDES "${INCLUDES}\\\\;${INCLUDE}" )
-			else()
-				set( INCLUDES "${INCLUDE}" )
-			endif()
+			list( APPEND CLI "-i" )
+			list( APPEND CLI "${INCLUDE}" )			
 		endforeach()
-		list( APPEND CLI "${INCLUDES}" )
 	endif()
 
 	# -o


### PR DESCRIPTION
I was having an issue where only 1 include directory was being picked up by shaderc. due to there only being one '-i' entry. When I looked at my executed command, the different include directories were separated by a space.

I fixed it by inserting a '-i' for every include directory.