### PR TITLE
Fix compiler flags for mixing objective/c++ in xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,23 @@ matrix:
     os: osx
     osx_image: xcode10
     env:
+      - CMAKE_FLAGS="-GXcode"
       - AMALGAMATED=OFF
 
   - name: "macOS Xcode 10 Amalgamated"
+    os: osx
+    osx_image: xcode10
+    env:
+      - CMAKE_FLAGS="-GXcode"
+      - AMALGAMATED=ON
+
+  - name: "macOS Xcode 10 (Makefiles)"
+    os: osx
+    osx_image: xcode10
+    env:
+      - AMALGAMATED=OFF
+
+  - name: "macOS Xcode 10 Amalgamated (Makefiles)"
     os: osx
     osx_image: xcode10
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if( APPLE AND NOT IOS )
+# Makefile generators on apple need this flag to compile mixed objective/c++
+if( APPLE AND NOT XCODE )
 	set( CMAKE_CXX_FLAGS "-ObjC++" )
 endif()
 

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -112,3 +112,8 @@ set_target_properties( bgfx PROPERTIES FOLDER "bgfx" )
 if( BGFX_USE_DEBUG_SUFFIX )
 	set_target_properties( bgfx PROPERTIES OUTPUT_NAME_DEBUG "bgfxd" )
 endif()
+
+# in Xcode we need to specify this file as objective-c++ (instead of renaming to .mm)
+if (XCODE)
+	set_source_files_properties(${BGFX_DIR}/src/renderer_vk.cpp PROPERTIES LANGUAGE OBJCXX XCODE_EXPLICIT_FILE_TYPE sourcecode.cpp.objcpp)
+endif()


### PR DESCRIPTION
With the new vulkan stuff in BGFX there are build issues when using the Xcode generator because renderer_vk.cpp is not recognised as mixed objective/c++ file (It needs the .mm extension for that to work).

e.g: 
```
/Applications/Xcode-11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObjCRuntime.h:504:61: error: unknown type name 'NSString'
FOUNDATION_EXPORT Protocol * _Nullable NSProtocolFromString(NSString *namestr) API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));
```

This fixes that by explicitly marking that file as a mixed source file. I also added travis jobs to build OSX with xcode (current jobs only build with makefiles, which don't have this issue for some reason I can't explain...)

