### PR TITLE
Set OpenGL (ES) minimum version without force-disabling other renderers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ option( BGFX_AMALGAMATED      "Amalgamated bgfx build for faster compilation" OF
 option( BX_AMALGAMATED        "Amalgamated bx build for faster compilation"   OFF )
 option( BGFX_CONFIG_DEBUG     "Enables debug configuration on all builds"     OFF )
 option( BGFX_USE_DEBUG_SUFFIX "Add 'd' suffix to debug output targets"        ON  )
-set( BGFX_OPENGL_VERSION  "" CACHE STRING "Specify minimum opengl version" )
+set( BGFX_OPENGL_VERSION   "" CACHE STRING "Specify minimum OpenGL version" )
+set( BGFX_OPENGLES_VERSION "" CACHE STRING "Specify minimum OpenGL ES version" )
 
 if( NOT BX_DIR )
 	set( BX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bx" CACHE STRING "Location of bx." )

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -49,7 +49,11 @@ if(BGFX_CONFIG_DEBUG)
 endif()
 
 if( NOT ${BGFX_OPENGL_VERSION} STREQUAL "" )
-	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGL=${BGFX_OPENGL_VERSION})
+	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGL_MIN_VERSION=${BGFX_OPENGL_VERSION} )
+endif()
+
+if( NOT ${BGFX_OPENGLES_VERSION} STREQUAL "" )
+	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGLES_MIN_VERSION=${BGFX_OPENGLES_VERSION} )
 endif()
 
 # Special Visual Studio Flags


### PR DESCRIPTION
Setting `BGFX_OPENGL_VERSION` sets `BGFX_CONFIG_RENDERER_OPENGL`. The problem with this is that, while bgfx has logic for enabling the correct renderers depending on the host, enabling/disabling any renderer manually [completely disables](https://github.com/bkaradzic/bgfx/blob/85b17c4a5cc23bdaef249c1c62b2e745908c8c00/src/config.h#L15) that logic.

The correct way to do this now is with `BGFX_CONFIG_RENDERER_OPENGL_MIN_VERSION` which doesn't affect the preprocessor logic.

I also added the same thing for OpenGL ES.