### PR TITLE
Update bx.cmake to include platform specific headers in target install include paths

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -35,20 +35,31 @@ if( WIN32 )
 	target_link_libraries( bx PUBLIC psapi )
 endif()
 
+include(GNUInstallDirs)
+
 # Add include directory of bx
 target_include_directories( bx
 	PUBLIC
 		$<BUILD_INTERFACE:${BX_DIR}/include>
 		$<BUILD_INTERFACE:${BX_DIR}/3rdparty>
-		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 # Build system specific configurations
 if( MSVC )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc> )
+	target_include_directories( bx
+		PUBLIC
+			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
 elseif( MINGW )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw> )
+	target_include_directories( bx
+		PUBLIC
+		    $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw>
+		    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/mingw> )
 elseif( APPLE )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx> )
+	target_include_directories( bx
+		PUBLIC
+		    $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx>
+		    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/osx> )
 endif()
 
 # All configurations


### PR DESCRIPTION
Hi there,

After building and installing bgfx using CMake on Windows, when including bx.h in my consuming application I hit the compile error that `alloca.h` could not be found.

There's a workaround for this in the bx repo where `compat/<platform>` folders are added to the target include folders - this change adds these paths for installed targets.

I also had to explicitly add `include(GNUInstallDirs)` as `${CMAKE_INSTALL_INCLUDEDIR}` seemed to not always be populated

Thanks!

Tom