### PR TITLE
Add `CMAKE_DEBUG_POSTFIX` to distinguish debug versions of built libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_DEBUG_POSTFIX "d")
 
 # Makefile generators on apple need this flag to compile mixed objective/c++
 if( APPLE AND NOT XCODE )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -35,20 +35,31 @@ if( WIN32 )
 	target_link_libraries( bx PUBLIC psapi )
 endif()
 
+include(GNUInstallDirs)
+
 # Add include directory of bx
 target_include_directories( bx
 	PUBLIC
 		$<BUILD_INTERFACE:${BX_DIR}/include>
 		$<BUILD_INTERFACE:${BX_DIR}/3rdparty>
-		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 # Build system specific configurations
 if( MSVC )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc> )
+	target_include_directories( bx
+		PUBLIC
+			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
 elseif( MINGW )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw> )
+	target_include_directories( bx
+		PUBLIC
+		    $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw>
+		    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/mingw> )
 elseif( APPLE )
-	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx> )
+	target_include_directories( bx
+		PUBLIC
+		    $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx>
+		    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/osx> )
 endif()
 
 # All configurations


### PR DESCRIPTION
In reference to: https://github.com/widberg/bgfx.cmake/issues/75#issue-615213441

This will ensure when building in config Debug, all built libraries will have `d` appended as a postfix. This is incredibly useful when installing libraries as it means both Debug and Release versions of the library can be installed to the same location.