### PR TITLE
Set bgfx PROJECT_VERSION from bgfx versioning scheme.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,10 @@
 # this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 cmake_minimum_required( VERSION 3.0 )
-project( bgfx )
+project(bgfx)
+
+# sets project version from api ver / git rev
+include( cmake/version.cmake )
 
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 set(CMAKE_CXX_STANDARD 14)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,37 @@
+# bgfx versioning scheme:
+# bgfx 1.104.7082
+#      ^ ^^^ ^^^^
+#      | |   +--- Commit number  (https://github.com/bkaradzic/bgfx / git rev-list --count HEAD)
+#      | +------- API version    (from https://github.com/bkaradzic/bgfx/blob/master/scripts/bgfx.idl#L4)
+#      +--------- Major revision (always 1)
+
+# BGFX_API_VERSION generated from https://github.com/bkaradzic/bgfx/blob/master/scripts/bgfx.idl#L4
+# bgfx/src/version.h:
+# BGFX_REV_NUMBER
+# BGFX_REV_SHA1
+
+find_package(Git QUIET)
+
+execute_process(COMMAND "${GIT_EXECUTABLE}" -C bgfx log --pretty=format:'%h' -n 1
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_REV
+                ERROR_QUIET)
+
+execute_process(COMMAND "${GIT_EXECUTABLE}" -C bgfx rev-list --count HEAD
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_REV_COUNT
+                ERROR_QUIET)
+
+# read version(100) from bgfx.idl
+file(READ "${CMAKE_SOURCE_DIR}/bgfx/scripts/bgfx.idl" BGFX_IDL)
+string(REGEX MATCH "version\\(([^\)]+)\\)"
+       BGFX_API_VERSION ${BGFX_IDL})
+set(BGFX_API_VERSION ${CMAKE_MATCH_1})
+set(BGFX_REV_NUMBER ${GIT_REV_COUNT})
+set(BGFX_REV ${GIT_REV})
+
+# set project specific versions
+set(PROJECT_VERSION 1.${BGFX_API_VERSION}.${BGFX_REV_NUMBER})
+set(PROJECT_VERSION_MAJOR 1)
+set(PROJECT_VERSION_MINOR ${BGFX_API_VERSION})
+set(PROJECT_VERSION_PATCH ${BGFX_REV_NUMBER})


### PR DESCRIPTION
bgfx has a versioning scheme as defined here: https://github.com/bkaradzic/bgfx/blob/master/src/bgfx.cpp#L3439-L3444

```
# bgfx versioning scheme:
# bgfx 1.104.7082
#      ^ ^^^ ^^^^
#      | |   +--- Commit number  (https://github.com/bkaradzic/bgfx / git rev-list --count HEAD)
#      | +------- API version    (from https://github.com/bkaradzic/bgfx/blob/master/scripts/bgfx.idl#L4)
#      +--------- Major revision (always 1)
```

We can generate this all ourself from Git / reading files as done in `cmake/version.cmake`.

It's important to set a version so package install targets work properly, plus it's quite vital to track the API_VERSION since it seems to change for breaking changes - I intend to lock to specific API_VERSIONs on my own project to avoid drastic breaking changes all the time.

Another thing that can be done but isn't currently is auto generating [version.h](https://github.com/bkaradzic/bgfx/blob/eaab1be0799c8e24f1037c23c0a7f52daa2d5e31/src/version.h) so bgfx internally knows it's version number. (Seems like this autogenerated file is committed sporadically so it's inaccurate as is).