### PR TITLE
Remove BGFX_USE_DEBUG_SUFFIX, should use CMAKE_DEBUG_POSTFIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ option( BGFX_USE_OVR          "Build with OVR support."                       OF
 option( BGFX_AMALGAMATED      "Amalgamated bgfx build for faster compilation" OFF )
 option( BX_AMALGAMATED        "Amalgamated bx build for faster compilation"   OFF )
 option( BGFX_CONFIG_DEBUG     "Enables debug configuration on all builds"     OFF )
-option( BGFX_USE_DEBUG_SUFFIX "Add 'd' suffix to debug output targets"        ON  )
 set( BGFX_OPENGL_VERSION   "" CACHE STRING "Specify minimum OpenGL version" )
 set( BGFX_OPENGLES_VERSION "" CACHE STRING "Specify minimum OpenGL ES version" )
 

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -117,11 +117,6 @@ endif()
 # Put in a "bgfx" folder in Visual Studio
 set_target_properties( bgfx PROPERTIES FOLDER "bgfx" )
 
-# Export debug build as "bgfxd"
-if( BGFX_USE_DEBUG_SUFFIX )
-	set_target_properties( bgfx PROPERTIES OUTPUT_NAME_DEBUG "bgfxd" )
-endif()
-
 # in Xcode we need to specify this file as objective-c++ (instead of renaming to .mm)
 if (XCODE)
 	set_source_files_properties(${BGFX_DIR}/src/renderer_vk.cpp PROPERTIES LANGUAGE OBJCXX XCODE_EXPLICIT_FILE_TYPE sourcecode.cpp.objcpp)

--- a/cmake/bimg.cmake
+++ b/cmake/bimg.cmake
@@ -42,8 +42,3 @@ target_link_libraries( bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt 
 
 # Put in a "bgfx" folder in Visual Studio
 set_target_properties( bimg PROPERTIES FOLDER "bgfx" )
-
-# Export debug build as "bimgd"
-if( BGFX_USE_DEBUG_SUFFIX )
-	set_target_properties( bimg PROPERTIES OUTPUT_NAME_DEBUG "bimgd" )
-endif()

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -88,8 +88,3 @@ endif()
 
 # Put in a "bgfx" folder in Visual Studio
 set_target_properties( bx PROPERTIES FOLDER "bgfx" )
-
-# Export debug build as "bxd"
-if( BGFX_USE_DEBUG_SUFFIX )
-	set_target_properties( bx PROPERTIES OUTPUT_NAME_DEBUG "bxd" )
-endif()


### PR DESCRIPTION
When building package install targets CMAKE_DEBUG_POSTFIX should be set to properly generate the install targets - this was impossible with BGFX_USE_DEBUG_SUFFIX interfering.