### PR TITLE
Generate modern CMake package config files on INSTALL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,47 +68,79 @@ include( cmake/examples.cmake )
 if( BGFX_INSTALL )
 	include(GNUInstallDirs)
 
-	# install bx
-	install( TARGETS bx
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-	install( DIRECTORY ${BX_DIR}/include DESTINATION . )
+	# Layout. This works for all platforms:
+	#   * <prefix>/lib*/cmake/<PROJECT-NAME>
+	#   * <prefix>/lib*/
+	#   * <prefix>/include/
+	set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+	set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
-	# install bimg
-	install( TARGETS bimg
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-	install( DIRECTORY ${BIMG_DIR}/include DESTINATION . )
+	# Configuration
+	set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+	set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+	set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+	set(namespace "${PROJECT_NAME}::")
 
-	# install bgfx
-	install( TARGETS bgfx
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-	install( DIRECTORY ${BGFX_DIR}/include DESTINATION . )
+	# Include module with fuction 'write_basic_package_version_file'
+	include(CMakePackageConfigHelpers)
 
-	# install export
-	install(
-		EXPORT bgfx-config
-		NAMESPACE bgfx::
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bgfx)
+	# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+	# Use:
+	#   * PROJECT_VERSION
+	write_basic_package_version_file(
+		"${version_config}"
+		VERSION ${PROJECT_VERSION}
+		COMPATIBILITY SameMinorVersion
+	)
+
+	# Configure '<PROJECT-NAME>Config.cmake'
+	# Use variables:
+	#   * TARGETS_EXPORT_NAME
+	#   * PROJECT_NAME
+	configure_package_config_file(
+		"cmake/Config.cmake.in"
+		"${project_config}"
+		INSTALL_DESTINATION "${config_install_dir}"
+	)
+
+	install(FILES ${BGFX_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+	install(FILES readme.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
+	install( TARGETS bgfx bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt pvrtc
+			 EXPORT "${TARGETS_EXPORT_NAME}"
+			 LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+			 ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+			 RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+			 INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+	)
+
+	# install headers (this should be done as a target probably... ^)
+	install( DIRECTORY ${BX_DIR}/include/bx ${BX_DIR}/include/compat ${BX_DIR}/include/tinystl DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+	install( DIRECTORY ${BIMG_DIR}/include/bimg DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+	install( DIRECTORY ${BGFX_DIR}/include/bgfx DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+	# header required for shader compilation
+	install( FILES ${BGFX_DIR}/src/bgfx_shader.sh ${BGFX_DIR}/src/bgfx_compute.sh
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/bgfx"
+	)
 
 	# install tools
 	if( BGFX_BUILD_TOOLS )
 		install( TARGETS shaderc
-			EXPORT bgfx-config
-			DESTINATION bin )
+			EXPORT "${TARGETS_EXPORT_NAME}"
+			DESTINATION "${CMAKE_INSTALL_BINDIR}" )
 		install( TARGETS geometryc
-			EXPORT bgfx-config
-			DESTINATION bin )
-    install( TARGETS geometryv
-			EXPORT bgfx-config
-			DESTINATION bin )
+			EXPORT "${TARGETS_EXPORT_NAME}"
+			DESTINATION "${CMAKE_INSTALL_BINDIR}" )
+    	install( TARGETS geometryv
+			EXPORT "${TARGETS_EXPORT_NAME}"
+			DESTINATION "${CMAKE_INSTALL_BINDIR}" )
 		install( TARGETS texturec
-			EXPORT bgfx-config
-			DESTINATION bin )
+			EXPORT "${TARGETS_EXPORT_NAME}"
+			DESTINATION "${CMAKE_INSTALL_BINDIR}" )
 		install( TARGETS texturev
-			EXPORT bgfx-config
-			DESTINATION bin )
+			EXPORT "${TARGETS_EXPORT_NAME}"
+			DESTINATION "${CMAKE_INSTALL_BINDIR}" )
 	endif()
 
 	# install examples
@@ -118,4 +150,20 @@ if( BGFX_INSTALL )
 			install( TARGETS example-${EXAMPLE} DESTINATION examples )
 		endforeach()
 	endif()
+
+	# Config
+	#   * <prefix>/lib/cmake/bgfx/bgfxConfig.cmake
+	#   * <prefix>/lib/cmake/bgfx/bgfxConfigVersion.cmake
+	install(
+		FILES "${project_config}" "${version_config}"
+		DESTINATION "${config_install_dir}"
+	)
+
+	# Config
+	#   * <prefix>/lib/cmake/bgfx/bgfxTargets.cmake
+	install(
+		EXPORT "${TARGETS_EXPORT_NAME}"
+		NAMESPACE "${namespace}"
+		DESTINATION "${config_install_dir}"
+	)
 endif()

--- a/cmake/3rdparty/astc-codec.cmake
+++ b/cmake/3rdparty/astc-codec.cmake
@@ -26,11 +26,3 @@ target_include_directories( astc-codec
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-codec>
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-codec/include> )
 set_target_properties( astc-codec PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS astc-codec
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/astc.cmake
+++ b/cmake/3rdparty/astc.cmake
@@ -17,11 +17,3 @@ file( GLOB ASTC_SOURCES ${BIMG_DIR}/3rdparty/astc/*.cpp ${BIMG_DIR}/3rdparty/ast
 add_library( astc STATIC ${ASTC_SOURCES} )
 target_include_directories( astc PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( astc PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS astc
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/edtaa3.cmake
+++ b/cmake/3rdparty/edtaa3.cmake
@@ -17,11 +17,3 @@ file( GLOB EDTAA3_SOURCES ${BIMG_DIR}/3rdparty/edtaa3/*.cpp ${BIMG_DIR}/3rdparty
 add_library( edtaa3 STATIC ${EDTAA3_SOURCES} )
 target_include_directories( edtaa3 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( edtaa3 PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS edtaa3
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/etc1.cmake
+++ b/cmake/3rdparty/etc1.cmake
@@ -17,11 +17,3 @@ file( GLOB ETC1_SOURCES ${BIMG_DIR}/3rdparty/etc1/*.cpp ${BIMG_DIR}/3rdparty/etc
 add_library( etc1 STATIC ${ETC1_SOURCES} )
 target_include_directories( etc1 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( etc1 PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS etc1
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/etc2.cmake
+++ b/cmake/3rdparty/etc2.cmake
@@ -18,11 +18,3 @@ add_library( etc2 STATIC ${ETC2_SOURCES} )
 target_include_directories( etc2 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( etc2 PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( etc2 PUBLIC bx )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS etc2
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/iqa.cmake
+++ b/cmake/3rdparty/iqa.cmake
@@ -17,11 +17,3 @@ file( GLOB IQA_SOURCES ${BIMG_DIR}/3rdparty/iqa/source/*.c ${BIMG_DIR}/3rdparty/
 add_library( iqa STATIC ${IQA_SOURCES} )
 target_include_directories( iqa PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/iqa/include> )
 set_target_properties( iqa PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS iqa
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/libsquish.cmake
+++ b/cmake/3rdparty/libsquish.cmake
@@ -17,11 +17,3 @@ file( GLOB SQUISH_SOURCES ${BIMG_DIR}/3rdparty/libsquish/*.cpp ${BIMG_DIR}/3rdpa
 add_library( squish STATIC ${SQUISH_SOURCES} )
 target_include_directories( squish PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( squish PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS squish
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/nvtt.cmake
+++ b/cmake/3rdparty/nvtt.cmake
@@ -34,11 +34,3 @@ target_include_directories( nvtt
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/nvtt> )
 set_target_properties( nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( nvtt PUBLIC bx )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS nvtt
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/3rdparty/pvrtc.cmake
+++ b/cmake/3rdparty/pvrtc.cmake
@@ -17,11 +17,3 @@ file( GLOB PVRTC_SOURCES ${BIMG_DIR}/3rdparty/pvrtc/*.cpp ${BIMG_DIR}/3rdparty/p
 add_library( pvrtc STATIC ${PVRTC_SOURCES} )
 target_include_directories( pvrtc PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
 set_target_properties( pvrtc PROPERTIES FOLDER "bgfx/3rdparty" )
-
-if( BGFX_INSTALL )
-	include(GNUInstallDirs)
-	install(
-		TARGETS pvrtc
-		EXPORT bgfx-config
-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@") 


### PR DESCRIPTION
Modifies the installation slightly to generate a modern CMake configuration installation target that can be included in a project like so:

```cmake
# bgfx_DIR = bgfx_install/lib/cmake/bgfx
find_package(bgfx)
target_link_libraries(my_exe bgfx::bgfx)
```

We also change the hard coded "bin", "lib", "include" paths to the CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBDIR, counterparts.

An example of the generated install directory:
- bin
- lib
  - cmake/bgfx
    - bgfxConfig.cmake
    - bgfxConfigVersion.cmake
    - bgfxTargets.cmake
    - bgfxTargets-debug.cmake
  - bgfx.lib
  - bgfxd.lib _(debug)_
  - ...
- share/doc/bgfx
  - LICENSE
  - readme.md

An example of building both Debug/Release binaries on Windows:

```bash
cmake -A "$(buildPlatform)" -DCMAKE_DEBUG_POSTFIX=d -DCMAKE_INSTALL_PREFIX=./install -DBGFX_BUILD_EXAMPLES=OFF -DBGFX_BUILD_TOOLS=ON -DBGFX_INSTALL=ON ..
cmake --build . --target install --config Debug
cmake --build . --target install --config Release
```

Depends on #80 #81 