### PR TITLE
spirv-cross.cmake webgpu support

### DIFF
--- a/cmake/3rdparty/spirv-cross.cmake
+++ b/cmake/3rdparty/spirv-cross.cmake
@@ -24,6 +24,7 @@ target_compile_definitions( spirv-cross PRIVATE SPIRV_CROSS_EXCEPTIONS_TO_ASSERT
 target_include_directories( spirv-cross PUBLIC
 	${BGFX_DIR}/3rdparty/spirv-cross
 	${BGFX_DIR}/3rdparty/spirv-cross/include
+	${BGFX_DIR}/3rdparty/webgpu/include
 )
 
 if( MSVC )


### PR DESCRIPTION
bgfx added webgpu, this is the main issue I came across when trying to compile with bgfx master.