### PR TITLE
travis: disable android and ios builds until they are fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,19 +65,19 @@ matrix:
     env:
       - AMALGAMATED=ON
 
-  - name: "iOS Xcode 10"
-    os: osx
-    osx_image: xcode10
-    env:
-     - CMAKE_FLAGS="-GXcode -DCMAKE_SYSTEM_NAME=iOS -DBGFX_BUILD_TOOLS=OFF -DCMAKE_OSX_SYSROOT=iphonesimulator"
-     - AMALGAMATED=OFF
+  #- name: "iOS Xcode 10"
+  #  os: osx
+  #  osx_image: xcode10
+  #  env:
+  #   - CMAKE_FLAGS="-GXcode -DCMAKE_SYSTEM_NAME=iOS -DBGFX_BUILD_TOOLS=OFF -DCMAKE_OSX_SYSROOT=iphonesimulator"
+  #   - AMALGAMATED=OFF
 
-  - name: "iOS Xcode 10 Amalgamated"
-    os: osx
-    osx_image: xcode10
-    env:
-     - CMAKE_FLAGS="-GXcode -DCMAKE_SYSTEM_NAME=iOS -DBGFX_BUILD_TOOLS=OFF -DCMAKE_OSX_SYSROOT=iphonesimulator"
-     - AMALGAMATED=ON
+  #- name: "iOS Xcode 10 Amalgamated"
+  #  os: osx
+  #  osx_image: xcode10
+  #  env:
+  #   - CMAKE_FLAGS="-GXcode -DCMAKE_SYSTEM_NAME=iOS -DBGFX_BUILD_TOOLS=OFF -DCMAKE_OSX_SYSROOT=iphonesimulator"
+  #   - AMALGAMATED=ON
 
   - name: "Visual studio 15 2017"
     os: windows
@@ -118,46 +118,46 @@ matrix:
     env:
       - AMALGAMATED=OFF
 
-  - name: "Android armeabi-v7a"
-    language: android
-    android: &androidComponents
-      components:
-        - tools
-        - platform-tools
-        - build-tools-26.0.1
-    env:
-      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
-      - AMALGAMATED=OFF
-    install: &androidInstall
-      - echo y | sdkmanager "cmake;3.10.2.4988404" 
-      - echo y | sdkmanager "lldb;3.1"
-      - sudo ln -sf /usr/local/android-sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
-      - wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
-      - unzip -qq android-ndk-r18b-linux-x86_64.zip
+  #- name: "Android armeabi-v7a"
+  #  language: android
+  #  android: &androidComponents
+  #    components:
+  #      - tools
+  #      - platform-tools
+  #      - build-tools-26.0.1
+  #  env:
+  #    - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+  #    - AMALGAMATED=OFF
+  #  install: &androidInstall
+  #    - echo y | sdkmanager "cmake;3.10.2.4988404" 
+  #    - echo y | sdkmanager "lldb;3.1"
+  #    - sudo ln -sf /usr/local/android-sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
+  #    - wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
+  #    - unzip -qq android-ndk-r18b-linux-x86_64.zip
 
-  - name: "Android armeabi-v7a Amalgamated"
-    language: android
-    android: *androidComponents
-    env:
-      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
-      - AMALGAMATED=ON
-    install: *androidInstall
+  #- name: "Android armeabi-v7a Amalgamated"
+  #  language: android
+  #  android: *androidComponents
+  #  env:
+  #    - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+  #    - AMALGAMATED=ON
+  #  install: *androidInstall
 
-  - name: "Android x86"
-    language: android
-    android: *androidComponents
-    env:
-      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
-      - AMALGAMATED=OFF
-    install: *androidInstall
+  #- name: "Android x86"
+  #  language: android
+  #  android: *androidComponents
+  #  env:
+  #    - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+  #    - AMALGAMATED=OFF
+  #  install: *androidInstall
 
-  - name: "Android x86 Amalgamated"
-    language: android
-    android: *androidComponents
-    env:
-      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
-      - AMALGAMATED=ON
-    install: *androidInstall
+  #- name: "Android x86 Amalgamated"
+  #  language: android
+  #  android: *androidComponents
+  #  env:
+  #    - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DBGFX_BUILD_TOOLS=OFF -DBGFX_BUILD_EXAMPLES=OFF -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r18b -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+  #    - AMALGAMATED=ON
+  #  install: *androidInstall
 
 script:
   - mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Todo
 -------------
 * Support Native Client.
 * Support Windows Phone.
+* Fix Android and iOS builds. [#85](https://github.com/widberg/bgfx.cmake/issues/85)
 * More configuration. [#12](https://github.com/widberg/bgfx.cmake/issues/12)
 * Add varying.def.sc files as shader dependencies.
 * Combined examples.


### PR DESCRIPTION
The test for Android and iOS have been broken for a while now.
Since PRs are still being made, I'm disabling those builds to that the travis test can indicate if other failures occur.
I created #85 and added a note to fix those test. Once fixed, they can be re-enabled.
For now, it serves no purpose to have the tests fail all the time.