### PR TITLE
Fix install readme.md which was changed to README.md (533a39f)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if( BGFX_INSTALL )
 	)
 
 	install(FILES ${BGFX_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
-	install(FILES readme.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+	install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 	install( TARGETS bgfx bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt pvrtc
 			 EXPORT "${TARGETS_EXPORT_NAME}"


### PR DESCRIPTION
533a39f changed readme.md to README.md breaking install(readme.md) on Linux systems due to case sensitivity.