### PR TITLE
Docs and licences install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,6 @@ if( BGFX_INSTALL )
 	)
 
 	install(FILES ${BGFX_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/licences/${PROJECT_NAME})
-	install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 	install( TARGETS bgfx bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt pvrtc
 			 EXPORT "${TARGETS_EXPORT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if( BGFX_INSTALL )
 		INSTALL_DESTINATION "${config_install_dir}"
 	)
 
-	install(FILES ${BGFX_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+	install(FILES ${BGFX_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/licences/${PROJECT_NAME})
 	install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 	install( TARGETS bgfx bimg bx astc-codec astc edtaa3 etc1 etc2 iqa squish nvtt pvrtc


### PR DESCRIPTION
bgfx.cmake's README is not documentation on how to use bgfx.
It is documentation on how to use bgfx.cmake to build, which is already once it's installed.
Therefore, there's no use to installing it on a system.

Licenses tend to be installed in `/usr/share/licenses/libname/`